### PR TITLE
Мелкое исправление очистки layout

### DIFF
--- a/interfaces/message_controller.py
+++ b/interfaces/message_controller.py
@@ -63,6 +63,9 @@ class MessageController:
         messages = self.message_area_content_layout.parentWidget().findChildren(MessageItem)
         for mes in messages:
             mes.deleteLater()
+        labels = self.message_area_content_layout.parentWidget().findChildren(QLabel)
+        for item in labels:
+            item.deleteLater()
 
         logger.info("clear MessagePole")
 


### PR DESCRIPTION
При удаление сообщений в layout оставались дочерние Qlabel со временем их число возрастало и появлялся ScrollBar
Добавил мелкую правку удаление child других типов. Удялять все чайлды нельзя, так как там еще "расширитель" который сталкивает виджеты вниз.

Исправляет issue #24 